### PR TITLE
Respect recurse and pattern parameters

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -82,7 +82,7 @@ async function require_context(filePath) {
           const res = path.resolve(dir, dirent.name);
 
           if (dirent.isDirectory()) {
-            return (recurse !== false) && getFiles(res);
+            return (recurse !== false) && getFiles(res, recurse, pattern);
           } else {
             return (!pattern || pattern.test(res)) ? res : null
           }


### PR DESCRIPTION
Calling getFiles recursively without these parameter prevented the recursion to
go further than one level and did not filtered files with pattern